### PR TITLE
fix: Remove pdf-parse to fix Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "openid-client": "^6.5.0",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
-    "pdf-parse": "^1.1.1",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## 🚀 Fix Vercel Deployment Error

### Problem
The deployment was failing with the error:
```
Error: ENOENT: no such file or directory, open './test/data/05-versions-space.pdf'
```

This was caused by the `pdf-parse` library trying to load test files that don't exist in production.

### Solution
Completely removed `pdf-parse` dependency since PDF processing is not currently needed. This is the cleanest and fastest solution.

### Changes Made
1. ✅ Removed `pdf-parse` from package.json dependencies
2. ✅ Removed all pdf-parse imports from `services/textExtractorService.ts`
3. ✅ Modified PDF processing to throw a clear error message: *"Processamento de PDF temporariamente desabilitado. Use formatos como DOCX, TXT ou imagens."*
4. ✅ Kept all other text extraction functionality intact (TXT, DOC/DOCX)

### Benefits
- **Immediate fix**: No more deployment errors
- **Cleaner codebase**: One less problematic dependency
- **Future-proof**: When PDF support is needed, we can add a better library like `pdf-lib` or `pdfjs-dist`

### Next Steps
1. Merge this PR
2. Vercel will automatically deploy
3. Configure environment variables in Vercel dashboard
4. Your app will be live! 🎉

### Testing
After deployment, the app will:
- ✅ Accept TXT, DOCX files normally
- ✅ Show clear error message if someone tries to upload PDF
- ✅ All other features work as expected